### PR TITLE
[Fix] Windows에서 생기는 DLL 빌드 오류 수정

### DIFF
--- a/GenerateProjectFiles.bat
+++ b/GenerateProjectFiles.bat
@@ -2,7 +2,7 @@
 
 if not exist "%~dp0Engine/CMakeLists.txt" goto Error_BatchFileInWrongLocation
 cmake -S "%~dp0Engine" -B "%~dp0Engine/build/intermediate" -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug
-cmake --build "%~dp0Engine/build/intermediate"
+cmake --build "%~dp0Engine/build/intermediate" --config Debug 
 exit /B %ERRORLEVEL%
 
 :Error_BatchFileInWrongLocation

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -40,7 +40,7 @@ if (MSVC)
     if (CMAKE_CXX_FLAGS MATCHES "/W[0-4]") # Force to always compile with W4
         string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /wd4201 /wd4244")
     endif()
 elseif (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wextra -Wall -Wno-long-long")
@@ -53,6 +53,13 @@ add_compile_definitions(
   $<IF:$<CONFIG:Debug>,CM_DEBUG,CM_RELEASE> # Set build-type define variable
   GLM_FORCE_SWIZZLE # force GLM to report the configuration as part of the build log
 )
+
+ # Set source and execution character set to UTF-8
+if(MSVC)
+add_compile_options(
+  /utf-8
+)
+endif()
 # -------------------------------------------------------------------------------
 # Set Position Independent code
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -296,6 +303,10 @@ if (MSVC)
   RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_SOURCE_DIR}/binary
   RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_SOURCE_DIR}/binary
   )
+  target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+  $<$<CONFIG:Debug>:CM_DEBUG>
+  $<$<CONFIG:Release>:CM_RELEASE>
+)
 endif (MSVC)
 
 # Pre-Compiled header

--- a/engine/external/README.md
+++ b/engine/external/README.md
@@ -1,3 +1,0 @@
-## External directory
-
-This directory contains source-code imported from other projects and not apart of Chimera.

--- a/engine/include/Chimera.h
+++ b/engine/include/Chimera.h
@@ -5,5 +5,7 @@
 #include "source/core/Application.h"
 #include "source/core/Logger.h"
 #include "imgui/imgui.h"
+#include "core/Layer.h"
+#include "core/Pch.h"
 
 #endif// CHIMERA_ENGINE_H

--- a/engine/source/core/Application.cpp
+++ b/engine/source/core/Application.cpp
@@ -8,7 +8,6 @@ namespace Cm
 
 Application::Application()
 {
-  sInstance = this;
   mWindow = std::unique_ptr<Window>( Window::CreateWindow() );
   mWindow->SetEventCallBack(
   std::bind( &Application::OnEvent, this, std::placeholders::_1 ) );
@@ -67,11 +66,6 @@ void Application::PushOverLay( Layer* overlay )
 {
   mLayerStack.PushOverlay( overlay );
   overlay->OnAttatch();
-}
-
-Application& Application::Get()
-{
-  return *sInstance;
 }
 
 bool Application::OnWindowCloseEvent( WindowCloseEvent& event )

--- a/engine/source/core/Application.cpp
+++ b/engine/source/core/Application.cpp
@@ -6,8 +6,6 @@
 namespace Cm
 {
 
-Application* Application::sInstance = nullptr;
-
 Application::Application()
 {
   sInstance = this;
@@ -69,6 +67,11 @@ void Application::PushOverLay( Layer* overlay )
 {
   mLayerStack.PushOverlay( overlay );
   overlay->OnAttatch();
+}
+
+Application& Application::Get()
+{
+  return *sInstance;
 }
 
 bool Application::OnWindowCloseEvent( WindowCloseEvent& event )

--- a/engine/source/core/Application.h
+++ b/engine/source/core/Application.h
@@ -10,31 +10,28 @@
 #include "imgui/ImguiLayer.h"
 namespace Cm
 {
-
-class CHIMERA_API Application
+class Application
 {
 public:
-  Application();
+  CHIMERA_API Application();
   virtual ~Application() = default;
 
-  void Run();
+  CHIMERA_API void Run();
 
-  void OnEvent( Event& event );
+  CHIMERA_API void OnEvent( Event& event );
 
-  void PushLayer( Layer* layer );
-  void PushOverLay( Layer* overlay );
+  CHIMERA_API void PushLayer( Layer* layer );
+  CHIMERA_API void PushOverLay( Layer* overlay );
 
-  static Application& Get()
-  {
-    return *sInstance;
-  }
+  CHIMERA_API static Application& Get();
+
   inline Window& GetWindow()
   {
     return *mWindow;
   }
 
 private:
-  bool OnWindowCloseEvent( WindowCloseEvent& event );
+  CHIMERA_API bool OnWindowCloseEvent( WindowCloseEvent& event );
 
 private:
   std::unique_ptr<Window> mWindow;
@@ -43,11 +40,12 @@ private:
   bool mRunning = true;
 
 private:
-  static Application* sInstance;
+  inline static Application* sInstance;
 };
 
 // To be defined in CLIENT
 std::unique_ptr<Application> CreateApplication();
 }// namespace Cm
+
 
 #endif// CHIMERA_ENGINE_SOURCE_CORE_APPLICATION_H

--- a/engine/source/core/Application.h
+++ b/engine/source/core/Application.h
@@ -23,7 +23,12 @@ public:
   CHIMERA_API void PushLayer( Layer* layer );
   CHIMERA_API void PushOverLay( Layer* overlay );
 
-  CHIMERA_API static Application& Get();
+  static Application& Get()
+  {
+    static Application sInstance;
+
+    return sInstance;
+  }
 
   inline Window& GetWindow()
   {
@@ -38,9 +43,6 @@ private:
   ImguiLayer* mImguiLayer;
   LayerStack mLayerStack;
   bool mRunning = true;
-
-private:
-  inline static Application* sInstance;
 };
 
 // To be defined in CLIENT

--- a/engine/source/core/Layer.cpp
+++ b/engine/source/core/Layer.cpp
@@ -1,9 +1,14 @@
 #include "core/Layer.h"
+#include "imgui/imgui.h"
+#include "imgui/imgui_impl_glfw.h"
+#include "imgui/imgui_impl_opengl3.h"
 
 namespace Cm
 {
-Layer::Layer( const std::string& name )
-    : mName( name )
+void Layer::DrawExample()
 {
+  ImGui::Begin( "Example" );
+  ImGui::Text( "Hello, world!" );
+  ImGui::End();
 }
 }// namespace Cm

--- a/engine/source/core/Layer.h
+++ b/engine/source/core/Layer.h
@@ -6,10 +6,14 @@
 
 namespace Cm
 {
-class CHIMERA_API Layer
+class Layer
 {
 public:
-  Layer( const std::string& name = "Layer" );
+  Layer( const std::string& name = "Layer" )
+      : mName( name )
+  {
+  }
+
   virtual ~Layer() = default;
 
   virtual void OnAttatch() {}
@@ -26,9 +30,12 @@ public:
     return mName;
   }
 
+  CHIMERA_API void DrawExample();
+
 private:
   std::string mName;
 };
+
 
 }// namespace Cm
 #endif

--- a/engine/source/core/LayerStack.h
+++ b/engine/source/core/LayerStack.h
@@ -5,16 +5,16 @@
 
 namespace Cm
 {
-class CHIMERA_API LayerStack
+class LayerStack
 {
 public:
   LayerStack() = default;
-  ~LayerStack();
+  CHIMERA_API ~LayerStack();
 
-  void PushLayer( Layer* layer );
-  void PushOverlay( Layer* overlay );
-  void PopLayer( Layer* layer );
-  void PopOverlay( Layer* overlay );
+  CHIMERA_API void PushLayer( Layer* layer );
+  CHIMERA_API void PushOverlay( Layer* overlay );
+  CHIMERA_API void PopLayer( Layer* layer );
+  CHIMERA_API void PopOverlay( Layer* overlay );
 
   std::vector<Layer*>::iterator begin()
   {

--- a/engine/source/core/Logger.cpp
+++ b/engine/source/core/Logger.cpp
@@ -2,8 +2,6 @@
 
 namespace Cm
 {
-std::shared_ptr<spdlog::logger> Logger::sCoreLogger;
-std::shared_ptr<spdlog::logger> Logger::sClientLogger;
 
 void Logger::Init()
 {
@@ -14,5 +12,15 @@ void Logger::Init()
 
   sClientLogger = spdlog::stdout_color_mt( "Scop" );
   sClientLogger->set_level( spdlog::level::trace );
+}
+
+std::shared_ptr<spdlog::logger>& Logger::GetCoreLogger()
+{
+  return sCoreLogger;
+}
+
+std::shared_ptr<spdlog::logger>& Logger::GetClientLogger()
+{
+  return sClientLogger;
 }
 }// namespace Cm

--- a/engine/source/core/Logger.h
+++ b/engine/source/core/Logger.h
@@ -10,23 +10,17 @@
 
 namespace Cm
 {
-class CHIMERA_API Logger
+class Logger
 {
 public:
-  static void Init();
+  CHIMERA_API static void Init();
 
-  inline static std::shared_ptr<spdlog::logger>& GetCoreLogger()
-  {
-    return sCoreLogger;
-  }
-  inline static std::shared_ptr<spdlog::logger>& GetClientLogger()
-  {
-    return sClientLogger;
-  }
+  CHIMERA_API static std::shared_ptr<spdlog::logger>& GetCoreLogger();
+  CHIMERA_API static std::shared_ptr<spdlog::logger>& GetClientLogger();
 
 private:
-  static std::shared_ptr<spdlog::logger> sCoreLogger;
-  static std::shared_ptr<spdlog::logger> sClientLogger;
+  inline static std::shared_ptr<spdlog::logger> sCoreLogger;
+  inline static std::shared_ptr<spdlog::logger> sClientLogger;
 };
 
 // Core Logger Macro

--- a/engine/source/imgui/ImguiLayer.h
+++ b/engine/source/imgui/ImguiLayer.h
@@ -5,16 +5,16 @@
 
 namespace Cm
 {
-class CHIMERA_API ImguiLayer : public Layer
+class ImguiLayer : public Layer
 {
 public:
-  ImguiLayer( const std::string& name );
-  virtual void OnAttatch() override;
-  virtual void OnDetach() override;
-  virtual void OnImguiRender() override;
+  CHIMERA_API ImguiLayer( const std::string& name );
+  CHIMERA_API virtual void OnAttatch() override;
+  CHIMERA_API virtual void OnDetach() override;
+  CHIMERA_API virtual void OnImguiRender() override;
 
-  void begin();
-  void end();
+  CHIMERA_API void begin();
+  CHIMERA_API void end();
 };
 
 }// namespace Cm

--- a/scop/CMakeLists.txt
+++ b/scop/CMakeLists.txt
@@ -58,9 +58,20 @@ set(SRC
   source/Scop.cpp
   )
 
+if(MSVC)
+  add_compile_options(/utf-8)
+endif()
+
 add_executable( ${CMAKE_PROJECT_NAME} ${SRC} )
 target_link_libraries( ${CMAKE_PROJECT_NAME} ${LIB} )
 target_include_directories( ${CMAKE_PROJECT_NAME} PUBLIC ${INC} )
+
+if(MSVC)
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+  $<$<CONFIG:Debug>:CM_DEBUG>
+  $<$<CONFIG:Release>:CM_RELEASE>
+)
+endif()
 
 # Set executable output directory
 set_target_properties(${CMAKE_PROJECT_NAME}

--- a/scop/setup.bat
+++ b/scop/setup.bat
@@ -2,8 +2,8 @@
 
 if not exist "%~dp0/setup.bat" goto Error_BatchFileInWrongLocation
 cmake -E remove_directory build/intermediate
-cmake -B build/intermediate -DBUILD_SHARED_LIBS=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE
-cmake --build build/intermediate -j4
+cmake -B build/intermediate -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build build/intermediate --config Debug -j4
 exit /B %ERRORLEVEL%
 
 :Error_BatchFileInWrongLocation

--- a/scop/source/Scop.cpp
+++ b/scop/source/Scop.cpp
@@ -17,9 +17,7 @@ public:
   }
   virtual void OnImguiRender() override
   {
-    ImGui::Begin( "Test" );
-    ImGui::Text( "Hello!!" );
-    ImGui::End();
+    DrawExample();
   }
 };
 


### PR DESCRIPTION
## DLL에서의 전역, 정적 변수

### 문제 코드
```
// Application.h

static Application& Get()
{
  return *sInstance;
}
```
헤더 파일에 함수를 정의하면 ChimeraEngineCore.dll, Scop.exe에서 Application::Get()을 호출할 때 각자의 메모리에 있는 sIntance를 불러오게 됩니다.

```
// 생성자에서 Application::Get()이 반환한 주소

[17:27:19] Chimera: Instance Address : 0x27e91127ce0
[17:27:19] Scop: Instance Address : 0x0
```
> DLL 소스 코드 파일에서 전역으로 선언된 변수는 컴파일러와 링커에서 전역 변수로 처리되지만 지정된 DLL을 로드하는 각 프로세스는 해당 DLL의 전역 변수에 대한 자체 복사본을 가져옵니다. 정적 변수의 범위는 정적 변수가 선언된 블록으로 제한됩니다. 결과적으로 각 프로세스에는 기본적으로 DLL 전역 및 정적 변수의 자체 인스턴스가 있습니다.
https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-data


### 해결 방법

1. sInstance를 자식 클래스에서 생성
 지금 엔진의 구조를 변경하기 때문에 좋지 않아 보입니다.

2. Application::Get()을 DLL 함수로 변경
 함수를 cpp 파일로 옮기고 DLL로 export했기 때문에 하나의 인스턴스에만 접근할 수 있습니다.
 초기화 시점이 명확하지 않고 생성되지 않은 인스턴스에 접근할 수 있습니다.
 엔진 코드에서 문제가 생길 부분은 없어 보이나, 향후 생길 수 있는 문제에 대비해 초기화 시점을 조절하면 좋을 것 같습니다.
 
3. 멤버 함수 내에서 정적 변수 초기화
```
// Application.cpp
// 헤더 파일의 sInstance 멤버 변수 삭제

Application& Application::Get()
{
  static Application sInstance;
  return sInstance;
}
```
Scop 프로세스에 sInstance가 생기지 않고, 변수의 초기화 시점을 명확하게 알 수 있어 좋을 것 같습니다.

## Scop에서 imgui UI 생성 시 발생하는 오류

ChimeraEngineCore.dll에 imgui가 링크되어 있기 때문에 전역 변수가 Scop에 복사되는 것 같습니다.
Cmake 설정을 바꿔 링크를 따로 하든지, Scop에서는 imgui 함수를 직접 호출하지 않아야 할 것 같습니다.

## 참고 자료
https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables
https://en.cppreference.com/w/cpp/language/initialization