### PR TITLE
[Fix] 싱글톤 객체가 두번 생성되는 문제 수정

### DIFF
--- a/engine/source/core/Application.cpp
+++ b/engine/source/core/Application.cpp
@@ -8,6 +8,8 @@ namespace Cm
 
 Application::Application()
 {
+  CM_ASSERT_DEV( "jinypark", ( !sInstance ), "Application already exists" );
+  sInstance = this;
   mWindow = std::unique_ptr<Window>( Window::CreateWindow() );
   mWindow->SetEventCallBack(
   std::bind( &Application::OnEvent, this, std::placeholders::_1 ) );

--- a/engine/source/core/Application.h
+++ b/engine/source/core/Application.h
@@ -25,9 +25,7 @@ public:
 
   static Application& Get()
   {
-    static Application sInstance;
-
-    return sInstance;
+    return *sInstance;
   }
 
   inline Window& GetWindow()
@@ -39,6 +37,7 @@ private:
   CHIMERA_API bool OnWindowCloseEvent( WindowCloseEvent& event );
 
 private:
+  inline static Application* sInstance;
   std::unique_ptr<Window> mWindow;
   ImguiLayer* mImguiLayer;
   LayerStack mLayerStack;


### PR DESCRIPTION
- Application이 클라이언트에서 생성되기 때문에 일반적으로 쓰이는 싱글톤 방식을 적용하기 어려울 것 같습니다.
- 제가 우려한 Application 중복 생성은 Assert문으로 막을 수 있게 했습니다.
- main문에서 바로 Application을 초기화하기 때문에, 지금 시점에서는 싱글톤 끼리의 의존성, 초기화 시점을 고려하지 않아도 될 것 같습니다.

```
// Scop.cpp
...
auto scop = Cm::CreateApplication();
auto scop2 = Cm::CreateApplication();
...
```

![image](https://github.com/42Chimera/chimera/assets/86358498/04810151-e177-46eb-bfa2-4bafcd6f7630)
